### PR TITLE
chore: ignore docs/ and .claude/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ target/
 
 # macOS
 .DS_Store
+
+# Local development docs (not for public repo)
+docs/
+
+# Claude Code local files
+.claude/


### PR DESCRIPTION
## Summary

- Adds `docs/` to `.gitignore` — local development notes have no place in the public repo
- Adds `.claude/` to `.gitignore` — local Claude Code session files

## Test plan

- [ ] `docs/` and `.claude/` no longer appear in `git status` after local changes