### PR TITLE
chore: bump maven-gpg-plugin to 3.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.7</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
Bumps `maven-gpg-plugin` from 3.2.7 to 3.2.8.

After merge, tag `v0.1.1` to trigger the Maven Central release workflow.