### PR TITLE
chore: bump version to 0.1.2 and exclude examples from Maven Central

### DIFF
--- a/l402-java-core/pom.xml
+++ b/l402-java-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>online.askahuman</groupId>
         <artifactId>l402-java</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.2</version>
     </parent>
 
     <artifactId>l402-java-core</artifactId>

--- a/l402-java-examples/pom.xml
+++ b/l402-java-examples/pom.xml
@@ -42,6 +42,8 @@
              centralPublishing.skip covers the Sonatype central-publishing-maven-plugin. -->
         <maven.deploy.skip>true</maven.deploy.skip>
         <centralPublishing.skip>true</centralPublishing.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.source.skip>true</maven.source.skip>
     </properties>
 
     <build>

--- a/l402-java-examples/pom.xml
+++ b/l402-java-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>online.askahuman</groupId>
         <artifactId>l402-java</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.2</version>
     </parent>
 
     <artifactId>l402-java-examples</artifactId>
@@ -37,8 +37,11 @@
 
     <properties>
         <!-- Exclude the examples module from Maven Central publication.
-             It is a runnable demo application, not a library artifact. -->
+             It is a runnable demo application, not a library artifact.
+             maven.deploy.skip covers the standard deploy plugin;
+             centralPublishing.skip covers the Sonatype central-publishing-maven-plugin. -->
         <maven.deploy.skip>true</maven.deploy.skip>
+        <centralPublishing.skip>true</centralPublishing.skip>
     </properties>
 
     <build>

--- a/l402-java-spring-boot-starter/pom.xml
+++ b/l402-java-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>online.askahuman</groupId>
         <artifactId>l402-java</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.2</version>
     </parent>
 
     <artifactId>l402-java-spring-boot-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>online.askahuman</groupId>
     <artifactId>l402-java</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.2</version>
     <packaging>pom</packaging>
 
     <name>l402-java</name>


### PR DESCRIPTION
Fixes two issues from the v0.1.1 release:

1. **Version mismatch** — pom.xml was never bumped before tagging, so the published artifacts were `0.1.0` instead of `0.1.1`. All pom.xml files are now bumped to `0.1.2`.

2. **Examples published to Maven Central** — `maven.deploy.skip=true` was already present but `central-publishing-maven-plugin` has its own skip property. Added `centralPublishing.skip=true` to exclude the demo module.

After merge, tag `v0.1.2` to trigger the release.