### PR TITLE
chore(ci): skip Security Review workflow on Renovate-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   security-scan:
+    if: github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Adds `if: github.actor != 'renovate[bot]'` to the `security-scan` job
- Prevents `anthropics/claude-code-action@v1` from failing with `Workflow initiated by non-human actor` on Renovate PRs

## Why not allow Renovate to trigger reviews
The Security Review prompt is designed for human-authored code changes. Dependency-bump PRs (which touch only `pom.xml`) yield no meaningful findings while still consuming API budget. Dependency vulnerabilities are already covered by:
- Renovate's `vulnerabilityAlerts: enabled` (raises security-labelled PRs at any time)
- The CI build job compiling and running tests against the new version

## Test plan
- [ ] Merge to `main`
- [ ] On the next Renovate PR, confirm `security-scan` job skips (not fails)
- [ ] Open a human-authored PR; `security-scan` still runs