### PR TITLE
chore(renovate): create PRs immediately + migrate deprecated config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,20 +24,20 @@
     {
       "description": "Group test dependencies",
       "groupName": "Test dependencies",
-      "matchPackagePrefixes": [
-        "org.junit",
-        "org.mockito",
-        "org.assertj",
-        "com.github.tomakehurst",
-        "org.wiremock"
+      "matchPackageNames": [
+        "org.junit{/,}**",
+        "org.mockito{/,}**",
+        "org.assertj{/,}**",
+        "com.github.tomakehurst{/,}**",
+        "org.wiremock{/,}**"
       ]
     },
     {
       "description": "Group Maven plugins",
       "groupName": "Maven plugins",
-      "matchPackagePrefixes": [
-        "org.apache.maven.plugins",
-        "org.jacoco"
+      "matchPackageNames": [
+        "org.apache.maven.plugins{/,}**",
+        "org.jacoco{/,}**"
       ]
     }
   ],
@@ -51,8 +51,6 @@
   },
 
   "prConcurrentLimit": 5,
-  "prCreation": "not-pending",
-  "prNotPendingHours": 2,
 
   "vulnerabilityAlerts": {
     "enabled": true,


### PR DESCRIPTION
## What

1. **Remove `prCreation: not-pending` + `prNotPendingHours: 2`** → Renovate opens dependency PRs immediately (the default).
2. **Migrate `matchPackagePrefixes` → `matchPackageNames`** (with `{/,}**` glob suffixes), clearing the "Config Migration Needed" notice on the Dependency Dashboard.

## Why

CI runs only on `pull_request` / `push: main`, so pushes to `renovate/*` branches produce zero status checks. With `prCreation: not-pending`, Renovate withheld PRs waiting for checks that never appear — throttling updates to a weekly trickle. Opening PRs immediately lets CI run on the PR as intended.

Config-only change.